### PR TITLE
fix: guarantee skill completion message display via bash echo

### DIFF
--- a/plugins/calibrator/commands/calibrate-review.md
+++ b/plugins/calibrator/commands/calibrate-review.md
@@ -214,15 +214,7 @@ SAFE_SKILL_PATH=$(escape_sql "$SKILL_OUTPUT_PATH/$SKILL_NAME")
 sqlite3 "$DB_PATH" "UPDATE patterns SET promoted = 1, skill_path = '$SAFE_SKILL_PATH' WHERE id = $PATTERN_ID;"
 
 # Output completion message (guaranteed to display)
-echo ""
-echo "✅ Skill created"
-echo ""
-echo "- $SKILL_OUTPUT_PATH/$SKILL_NAME/SKILL.md"
-echo ""
-echo "🔄 To activate this Skill, start a new Claude Code session."
-echo "   (Skills are loaded at session start)"
-echo ""
-echo "Claude will then automatically apply this rule in \"$SITUATION\" situations."
+printf '\n✅ Skill created\n\n- %s/%s/SKILL.md\n\n🔄 To activate this Skill, start a new Claude Code session.\n   (Skills are loaded at session start)\n\nClaude will then automatically apply this rule in "%s" situations.\n' "$SKILL_OUTPUT_PATH" "$SKILL_NAME" "$SITUATION"
 ```
 
 ## Reference: Skill Name Conversion Rules


### PR DESCRIPTION
## Summary
- Move completion message from markdown template (Step 6) to bash `echo` output in Step 5
- Guarantees 100% display when skill is promoted
- Claude may skip markdown-only messages, but bash output is always shown

## Changes
```bash
# Output completion message (guaranteed to display)
echo "✅ Skill created"
echo "- $SKILL_OUTPUT_PATH/$SKILL_NAME/SKILL.md"
echo "🔄 To activate this Skill, start a new Claude Code session."
echo "   (Skills are loaded at session start)"
echo "Claude will then automatically apply this rule in \"$SITUATION\" situations."
```

## Test plan
- [ ] Run `/calibrate-review` to promote a pattern
- [ ] Verify completion message with session restart guidance is displayed
- [ ] Confirm message appears in script output (not just as Claude's response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated calibration completion messaging with dynamic variable substitution and improved formatting to provide clearer activation instructions and final guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->