### PR TITLE
docs: add step-by-step example and detailed command usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,138 @@ Promote to Skill with /calibrate review
 Claude automatically applies pattern going forward
 ```
 
+## Example: Teaching Claude Your Preferences
+
+Let's walk through a real scenario from start to finish.
+
+### 😤 The Problem
+
+You ask Claude to create a React component:
+
+```
+> Create a Button component
+```
+
+Claude responds:
+```jsx
+const Button = ({ label, onClick }) => {
+  return <button onClick={onClick}>{label}</button>
+}
+```
+
+**But you wanted TypeScript interfaces!** This keeps happening...
+
+---
+
+### 📝 Step 1: Record the Mismatch
+
+Run `/calibrate` right after the mismatch:
+
+```
+What kind of mismatch just happened?
+> 1. Something was missing
+
+Situation: > Creating React components
+Expected: > TypeScript interface for props
+Instruction: > Always define a TypeScript interface for component props
+```
+
+Result:
+```
+✅ Record complete
+Same pattern accumulated 1 times
+```
+
+---
+
+### 🔄 Step 2: Pattern Repeats
+
+A few days later, same thing happens with a Modal component. Run `/calibrate` again with the same situation and instruction.
+
+```
+✅ Record complete
+Same pattern accumulated 2 times
+
+💡 You can promote this to a Skill with /calibrate review.
+```
+
+---
+
+### ⬆️ Step 3: Promote to Skill
+
+Run `/calibrate review`:
+
+```
+📊 Skill Promotion Candidates (2+ repetitions)
+
+[id=1] Creating React components → Always define a TypeScript interface... (2 times)
+
+Enter pattern id(s) to promote: > 1
+```
+
+Preview and save:
+```
+📝 Skill Preview: Creating React components
+...
+[Save] [Edit] [Skip]
+> Save
+
+✅ Skill created: .claude/skills/creating-react-components/SKILL.md
+```
+
+---
+
+### ✨ Result: Before vs After
+
+**Restart Claude Code**, then ask the same question:
+
+```
+> Create a Button component
+```
+
+Now Claude responds:
+```tsx
+interface ButtonProps {
+  label: string;
+  onClick: () => void;
+}
+
+const Button = ({ label, onClick }: ButtonProps) => {
+  return <button onClick={onClick}>{label}</button>
+}
+```
+
+🎉 **Claude learned your preference and applies it automatically!**
+
+---
+
+## Best Practice
+
+The recommended workflow for effective calibration:
+
+```
+1. Work with Claude as usual
+       ↓
+2. Notice a mismatch? Run /calibrate immediately
+       ↓
+3. Be specific: "When creating React components" > "When coding"
+       ↓
+4. Write clear instructions: "Always use TypeScript interfaces"
+       ↓
+5. Let patterns accumulate naturally (2+ times)
+       ↓
+6. Review with /calibrate review weekly
+       ↓
+7. Restart Claude Code to activate new Skills
+```
+
+**Tips:**
+- 📝 Record mismatches **right when they happen** - context matters
+- 🎯 Be **specific** about the situation - vague patterns don't help
+- ✍️ Write **imperative instructions** - "Always do X" or "Never do Y"
+- 🔄 **Check `/calibrate status`** regularly to see accumulated patterns
+- 🚀 After promoting Skills, **restart Claude Code** to load them
+
 ## Installation
 
 ```bash
@@ -46,9 +178,52 @@ Claude automatically applies pattern going forward
 /calibrate init
 ```
 
-Creates:
-- `.claude/calibrator/patterns.db`
-- `.claude/skills/learned/` directory
+Creates the Calibrator database and directory structure.
+
+<details>
+<summary>📖 Detailed Usage</summary>
+
+**What it creates:**
+- `.claude/calibrator/patterns.db` - SQLite database
+- `.claude/skills/learned/` - Directory for promoted Skills
+- Adds entries to `.gitignore` (for Git projects)
+
+**Flow:**
+
+1. **New Installation:**
+   ```
+   ⚙️ Calibrator Initialization
+
+   Files to create:
+   - .claude/calibrator/patterns.db
+
+   [Confirm] [Cancel]
+   ```
+
+2. **If Already Exists:**
+   ```
+   ⚠️ Calibrator already exists
+
+   Current files:
+   - .claude/calibrator/patterns.db
+
+   [Keep] [Reinitialize (delete data)]
+   ```
+
+3. **Completion:**
+   ```
+   ✅ Calibrator initialization complete
+
+   - .claude/calibrator/patterns.db created
+   - .claude/skills/learned/ directory created
+   - .gitignore updated (if Git project)
+
+   You can now record mismatches with /calibrate.
+   ```
+
+</details>
+
+---
 
 ### Record Mismatches
 
@@ -56,10 +231,63 @@ Creates:
 /calibrate
 ```
 
-Record patterns when Claude generates something different from your expectations:
-1. Select category (missing/excess/style/other)
-2. Enter situation and expectation
-3. Automatically saved to database
+Record patterns when Claude generates something different from your expectations.
+
+<details>
+<summary>📖 Detailed Usage</summary>
+
+**Step 1: Category Selection**
+```
+What kind of mismatch just happened?
+
+1. Something was missing
+2. There was something unnecessary
+3. I wanted a different approach
+4. Let me explain
+```
+
+| Choice | Category |
+|--------|----------|
+| 1 | `missing` |
+| 2 | `excess` |
+| 3 | `style` |
+| 4 | `other` |
+
+**Step 2: Input Details**
+```
+In what situation, and what did you expect?
+Example: "When creating a model, include timestamp field"
+
+Situation: [your input]
+Expected: [your input]
+Instruction (imperative rule to learn): [your input]
+```
+
+| Field | Description | Max Length |
+|-------|-------------|------------|
+| Situation | When does this apply? | 500 chars |
+| Expected | What did you expect? | 1000 chars |
+| Instruction | Rule for Claude to learn | 2000 chars |
+
+**Step 3: Confirmation**
+```
+✅ Record complete
+
+Situation: {situation}
+Expected: {expectation}
+Instruction: {instruction}
+
+Same pattern accumulated {count} times
+```
+
+If the pattern repeats 2+ times:
+```
+💡 You can promote this to a Skill with /calibrate review.
+```
+
+</details>
+
+---
 
 ### Review & Promote to Skills
 
@@ -67,10 +295,74 @@ Record patterns when Claude generates something different from your expectations
 /calibrate review
 ```
 
-Promote patterns that have repeated 2+ times to Skills:
-- View list of promotion candidates
-- Preview and edit Skill before saving
-- Creates `SKILL.md` in `.claude/skills/learned/`
+Promote patterns that have repeated 2+ times to Skills.
+
+<details>
+<summary>📖 Detailed Usage</summary>
+
+**Step 1: View Candidates**
+```
+📊 Skill Promotion Candidates (2+ repetitions)
+
+[id=12] Model creation → Always include timestamp fields (3 times)
+[id=15] API endpoint → Always include error handling (2 times)
+
+Enter pattern id(s) to promote (comma-separated for multiple): _
+```
+
+If no candidates:
+```
+📊 No patterns available for promotion
+
+Patterns need to repeat 2+ times to be promoted to a Skill.
+Keep recording with /calibrate.
+```
+
+**Step 2: Skill Preview**
+```
+📝 Skill Preview: {situation}
+
+---
+name: {kebab-case situation}
+description: {instruction}. Auto-applied in {situation} situations.
+learned_from: calibrator ({count} repetitions, {first_seen} ~ {last_seen})
+---
+
+## Rules
+
+{instruction}
+
+## Applies to
+
+- {situation}
+
+## Learning History
+
+This Skill was auto-generated by Calibrator.
+- First detected: {first_seen}
+- Last detected: {last_seen}
+- Repetitions: {count}
+
+---
+
+[Save] [Edit] [Skip]
+```
+
+**Step 3: Result**
+```
+✅ Skill created
+
+- .claude/skills/{skill-name}/SKILL.md
+
+🔄 To activate this Skill, start a new Claude Code session.
+   (Skills are loaded at session start)
+
+Claude will then automatically apply this rule in "{situation}" situations.
+```
+
+</details>
+
+---
 
 ### View Statistics
 
@@ -78,10 +370,42 @@ Promote patterns that have repeated 2+ times to Skills:
 /calibrate status
 ```
 
-- Total observation records
-- Detected pattern count
-- Skill promotion status
-- Recent records
+View currently recorded patterns and statistics.
+
+<details>
+<summary>📖 Detailed Usage</summary>
+
+**Output:**
+```
+📊 Calibrator Status
+
+Total observations: {count}
+Detected patterns: {count}
+├─ Promoted to Skills: {count}
+└─ Pending promotion (2+): {count}
+
+Recent records:
+- [{timestamp}] {category}: {situation}
+- [{timestamp}] {category}: {situation}
+- [{timestamp}] {category}: {situation}
+```
+
+If pending patterns exist:
+```
+💡 Run /calibrate review to promote pending patterns to Skills.
+```
+
+If no data recorded:
+```
+📊 Calibrator Status
+
+No data recorded yet.
+Record your first mismatch with /calibrate.
+```
+
+</details>
+
+---
 
 ### Reset Data
 
@@ -89,7 +413,43 @@ Promote patterns that have repeated 2+ times to Skills:
 /calibrate reset
 ```
 
-Deletes all observation records and patterns. Generated Skills are preserved.
+⚠️ Deletes all observation records and patterns. Generated Skills are preserved.
+
+<details>
+<summary>📖 Detailed Usage</summary>
+
+**Step 1: Current Status**
+```
+⚠️ Calibrator Reset
+
+Database file:
+- {DB_PATH}
+
+Data to delete:
+- {count} observations
+- {count} patterns
+
+Note: Generated Skills (.claude/skills/learned/) will be preserved.
+
+Really reset? Type "reset" to confirm: _
+```
+
+**Step 2: Confirmation**
+- Type `reset` to proceed
+- Any other input cancels the operation
+
+**Step 3: Result**
+```
+✅ Calibrator data has been reset
+
+- Observations: all deleted
+- Patterns: all deleted
+- Skills: preserved (.claude/skills/learned/)
+
+Start new records with /calibrate.
+```
+
+</details>
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Add complete tutorial example showing the full calibration workflow with before/after comparison
- Add Best Practice section with recommended workflow and tips
- Add collapsible detailed usage sections for all 5 commands
- Improve documentation structure for better first-time user experience

## Changes

### New Sections
- **Example: Teaching Claude Your Preferences** - Real scenario walkthrough (problem → record → repeat → promote → result)
- **Best Practice** - Recommended workflow with tips

### Enhanced Command Documentation
Each command now includes collapsible `<details>` sections with:
- `/calibrate init`: Installation flow, confirmation dialogs, completion message
- `/calibrate`: Category selection (4 options), input fields with max lengths, confirmation
- `/calibrate review`: Candidate list, skill preview format, result messages
- `/calibrate status`: Output format, conditional messages
- `/calibrate reset`: Confirmation prompt, preserved items

## Why
First-time users found the abstract flow diagram hard to understand. The new example section provides a concrete scenario that demonstrates the complete workflow from start to finish.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with comprehensive, structured guidance including detailed example workflows
  * Added step-by-step instructions for key workflows with sample interactive prompts
  * Enhanced sections with collapsible details, tables, and usage scenarios for improved clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->